### PR TITLE
Common.Logging.Core has been deprecated

### DIFF
--- a/FreeSwitchSharp/FreeSwitchSharp.csproj
+++ b/FreeSwitchSharp/FreeSwitchSharp.csproj
@@ -31,10 +31,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Common.Logging">
-      <HintPath>..\packages\Common.Logging.2.2.0\lib\net40\Common.Logging.dll</HintPath>
-    </Reference>
-    <Reference Include="Common.Logging.Core">
-      <HintPath>..\packages\Common.Logging.Core.2.2.0\lib\net40\Common.Logging.Core.dll</HintPath>
+      <HintPath>..\packages\Common.Logging.2.3.1\lib\net40\Common.Logging.dll</HintPath>
     </Reference>
     <Reference Include="ManagedEsl">
       <HintPath>..\Libs\ManagedEsl.dll</HintPath>

--- a/FreeSwitchSharp/FreeSwitchSharp.csproj
+++ b/FreeSwitchSharp/FreeSwitchSharp.csproj
@@ -31,7 +31,10 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Common.Logging">
-      <HintPath>..\packages\Common.Logging.2.3.1\lib\net40\Common.Logging.dll</HintPath>
+      <HintPath>..\packages\Common.Logging.3.0.0\lib\net40\Common.Logging.dll</HintPath>
+    </Reference>
+    <Reference Include="Common.Logging.Core">
+      <HintPath>..\packages\Common.Logging.Core.3.0.0\lib\net40\Common.Logging.Core.dll</HintPath>
     </Reference>
     <Reference Include="ManagedEsl">
       <HintPath>..\Libs\ManagedEsl.dll</HintPath>

--- a/FreeSwitchSharp/FreeSwitchSharp.nuspec
+++ b/FreeSwitchSharp/FreeSwitchSharp.nuspec
@@ -15,8 +15,8 @@
 		<tags>FreeSwitch FreeSwitchSharp VoIP</tags>
 
 		<dependencies>
-			<dependency id="Common.Logging" version="2.2.0" />
-			<dependency id="Common.Logging.Core" version="2.2.0" />
+			<dependency id="Common.Logging" version="3.0.0" />
+			<dependency id="Common.Logging.Core" version="3.0.0" />
 		</dependencies>
 	</metadata>
 	<files>

--- a/FreeSwitchSharp/packages.config
+++ b/FreeSwitchSharp/packages.config
@@ -1,6 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Common.Logging" version="2.2.0" targetFramework="net45" />
-  <package id="Common.Logging.Core" version="2.2.0" targetFramework="net45" />
+  <package id="Common.Logging" version="2.3.1" targetFramework="net45" />
   <package id="ILRepack.MSBuild.Task" version="1.0.9" targetFramework="net45" />
 </packages>

--- a/FreeSwitchSharp/packages.config
+++ b/FreeSwitchSharp/packages.config
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Common.Logging" version="2.3.1" targetFramework="net45" />
+  <package id="Common.Logging" version="3.0.0" targetFramework="net45" />
+  <package id="Common.Logging.Core" version="3.0.0" targetFramework="net45" />
   <package id="ILRepack.MSBuild.Task" version="1.0.9" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
I use the latest version of Common.Logging in my project. When I added your great package to my project, I got a lot of errors because the latest versions of Common.Logging and Common.Logging.Core define essentially the same types. It can be worked around, though, by defining an alias for Common.Logging.Core. Removing the dependency on Common.Logging.Core is a much cleaner approach IMO.
